### PR TITLE
Hide paginator if only one page

### DIFF
--- a/bsct/templates/bsct/plain/paginator.html
+++ b/bsct/templates/bsct/plain/paginator.html
@@ -1,4 +1,5 @@
 {% load bscttags %}
+{% if is_paginated %}
 <div class="pagination">
     <ul class="pagination">
         <li 
@@ -41,3 +42,4 @@
         </li>
     </ul>
 </div>
+{% endif %}


### PR DESCRIPTION
When there is only one page, we can hide the paginator block as it will be useless.
